### PR TITLE
Fix: Scope overlay CSS to prevent global style conflicts

### DIFF
--- a/overlay.css
+++ b/overlay.css
@@ -1,4 +1,4 @@
-body {
+#container {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
     background-color: #f4f4f8;
     color: #333;
@@ -7,20 +7,21 @@ body {
     padding: 16px;
 }
 
-.container {
+/*#container .container { Removed as #container is the container itself */
+#container {
     display: flex;
     flex-direction: column;
     gap: 20px;
 }
 
-header {
+#container header {
     display: flex;
     align-items: center;
     gap: 12px;
     border-bottom: 1px solid #ddd;
     padding-bottom: 12px;
 }
-header h1 {
+#container header h1 {
     font-size: 20px;
     margin: 0;
     color: #111;
@@ -33,30 +34,30 @@ header h1 {
     box-shadow: 0 2px 4px rgba(0,0,0,0.05);
 }
 
-h2 {
+#container h2 {
     font-size: 16px;
     margin-top: 0;
     margin-bottom: 8px;
     color: #4f46e5;
 }
 
-p {
+#container p {
     font-size: 14px;
     color: #555;
     margin: 0 0 12px 0;
     line-height: 1.5;
 }
 
-label {
+#container label {
     display: block;
     font-weight: 600;
     margin-bottom: 6px;
     font-size: 14px;
 }
 
-input[type="password"],
-input[type="text"],
-textarea {
+#container input[type="password"],
+#container input[type="text"],
+#container textarea {
     width: 100%;
     padding: 10px;
     border: 1px solid #ccc;
@@ -64,24 +65,24 @@ textarea {
     font-size: 14px;
     box-sizing: border-box; /* Important */
 }
-input:focus, textarea:focus {
+#container input:focus, #container textarea:focus {
     outline: none;
     border-color: #4f46e5;
     box-shadow: 0 0 0 2px #c7d2fe;
 }
 
-textarea {
+#container textarea {
     resize: vertical;
 }
 
-footer {
+#container footer {
     display: flex;
     align-items: center;
     justify-content: space-between;
     margin-top: 10px;
 }
 
-button {
+#container button {
     background-color: #4f46e5;
     color: white;
     border: none;
@@ -92,35 +93,35 @@ button {
     cursor: pointer;
     transition: background-color 0.2s ease;
 }
-button:hover {
+#container button:hover {
     background-color: #4338ca;
 }
 
-#status-msg {
+#status-msg { /* ID is unique, no need to scope to #container */
     color: #16a34a;
     font-weight: 600;
     margin: 0;
 }
 
 /* Toggle Switch Styles */
-.toggle-group {
+#container .toggle-group {
     display: flex;
     align-items: center;
     gap: 12px;
     margin-bottom: 12px;
 }
-.switch {
+#container .switch {
     position: relative;
     display: inline-block;
     width: 44px;
     height: 24px;
 }
-.switch input {
+#container .switch input {
     opacity: 0;
     width: 0;
     height: 0;
 }
-.slider {
+#container .slider {
     position: absolute;
     cursor: pointer;
     top: 0;
@@ -131,7 +132,7 @@ button:hover {
     transition: .4s;
     border-radius: 24px;
 }
-.slider:before {
+#container .slider:before {
     position: absolute;
     content: "";
     height: 18px;
@@ -142,17 +143,17 @@ button:hover {
     transition: .4s;
     border-radius: 50%;
 }
-input:checked + .slider {
+#container input:checked + .slider {
     background-color: #4f46e5;
 }
-input:checked + .slider:before {
+#container input:checked + .slider:before {
     transform: translateX(20px);
 }
 
-.stats p {
+#container .stats p {
     margin-bottom: 8px;
 }
-.stats p:last-child {
+#container .stats p:last-child {
     margin-bottom: 0;
     font-style: italic;
     font-size: 12px;


### PR DESCRIPTION
The CSS styles in `overlay.css` were unintentionally affecting your entire host page due to a global `body` selector and other unscoped element selectors. This caused the page layout to shift and the background color to change.

This commit resolves the issue by:
- Changing the `body` selector in `overlay.css` to target the `#container` ID, which is the root element of the overlay's content in `overlay.html`.
- Prefixing other general CSS selectors (e.g., `header`, `h1`, `p`, `input`, `button`) with `#container` to ensure they are scoped to the overlay.

These changes prevent the extension's styles from leaking out and modifying your host page, while ensuring the overlay itself remains styled as intended.